### PR TITLE
feat: add telegram interface

### DIFF
--- a/apps/api/src/app/auth/test_resend_signin_code.rs
+++ b/apps/api/src/app/auth/test_resend_signin_code.rs
@@ -8,14 +8,14 @@ mod tests {
     use serde_variant::to_variant_name;
     use serial_test::serial;
     use surrealdb::opt::PatchOp;
+    use telegram_bot::TelegramClient;
 
     use crate::{
         app::{
             auth::{
                 get_router, ResendSigninCodePayload, ResendSigninCodeStatus, SendSigninCodePayload,
                 SendSigninCodeStatus,
-            },
-            AppState,
+            }, common::MessagingChannel, AppState
         },
         database::{Database, SigninCode},
         whatsapp::{MockWhatsAppBot, WASendMessageResponse, WhatsAppStatus},
@@ -23,7 +23,11 @@ mod tests {
 
     async fn setup() -> (Arc<Database>, TestServer) {
         let db = Arc::new(Database::in_memory().await);
-        let state = Arc::new(AppState { db: db.clone() });
+        let telegram = TelegramClient::for_testing();
+        let state = Arc::new(AppState {
+            db: db.clone(),
+            telegram,
+        });
         let router = get_router().with_state(state).into_make_service();
 
         (db.clone(), TestServer::new(router).unwrap())
@@ -49,6 +53,7 @@ mod tests {
 
         let payload = SendSigninCodePayload {
             phone_number: "+201096707442".to_string(),
+            channel: MessagingChannel::WhatsApp,
         };
 
         let response = server.post("/send_signin_code").json(&payload).await;
@@ -63,6 +68,7 @@ mod tests {
 
         let payload = ResendSigninCodePayload {
             phone_number: "+201096707442".to_string(),
+            channel: MessagingChannel::WhatsApp,
         };
 
         let response = server.post("/resend_signin_code").json(&payload).await;
@@ -96,6 +102,7 @@ mod tests {
 
         let payload = SendSigninCodePayload {
             phone_number: "+201096707442".to_string(),
+            channel: MessagingChannel::WhatsApp,
         };
 
         let response = server.post("/send_signin_code").json(&payload).await;
@@ -120,6 +127,7 @@ mod tests {
 
         let payload = ResendSigninCodePayload {
             phone_number: "+201096707442".to_string(),
+            channel: MessagingChannel::WhatsApp,
         };
 
         let response = server.post("/resend_signin_code").json(&payload).await;
@@ -144,6 +152,7 @@ mod tests {
 
         let payload = ResendSigninCodePayload {
             phone_number: "+201096707442".to_string(),
+            channel: MessagingChannel::WhatsApp,
         };
 
         let response = server.post("/resend_signin_code").json(&payload).await;

--- a/apps/api/src/app/common.rs
+++ b/apps/api/src/app/common.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum MessagingChannel {
+    WhatsApp,
+    Telegram,
+}

--- a/apps/api/src/app/mod.rs
+++ b/apps/api/src/app/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use admin::AdminSecurityAddon;
 use axum::Router;
 use serde::Serialize;
+use telegram_bot::TelegramClient;
 use utoipa::{Modify, OpenApi};
 use utoipa_swagger_ui::SwaggerUi;
 use utoipauto::utoipauto;
@@ -13,6 +14,7 @@ use crate::database::Database;
 mod admin;
 mod auth;
 mod sync;
+mod common;
 
 #[utoipauto(paths = "./apps/api/src/app")]
 #[derive(OpenApi)]
@@ -41,11 +43,12 @@ pub struct AppErrorResponse {
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<Database>,
+    pub telegram: Arc<TelegramClient>,
 }
 
 impl AppState {
-    pub fn new(db: Arc<Database>) -> Self {
-        Self { db }
+    pub fn new(db: Arc<Database>, telegram: Arc<TelegramClient>) -> Self {
+        Self { db, telegram }
     }
 }
 

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -60,7 +60,8 @@ async fn main() {
     whatsapp::WhatsAppBot::initialize_whatsapp();
 
     debug!(target: LOG_TARGET, "Initializing Telegram");
-    TelegramClient::init::<ConsoleAuthorizationHandler, ConsoleConnectionHandler>().await;
+    let telegram_client =
+        TelegramClient::init::<ConsoleAuthorizationHandler, ConsoleConnectionHandler>().await;
 
     debug!(target: LOG_TARGET, "Connecting to the database");
     let database = Arc::new(Database::new());
@@ -87,6 +88,7 @@ async fn main() {
         .layer(svc)
         .with_state(Arc::new(app::AppState {
             db: database.clone(),
+            telegram: telegram_client.clone(),
         }))
         .into_make_service();
 

--- a/apps/desktop/src/central/auth.ts
+++ b/apps/desktop/src/central/auth.ts
@@ -3,7 +3,7 @@ import type { CentralClient } from 'central';
 import { StringRecordId, type ScopeAuth } from 'surrealdb.js';
 import type Surreal from 'surrealdb.js';
 import { jwtDecode } from 'jwt-decode';
-import type { SurrealDBToken } from 'common';
+import type { MessagingChannel, SurrealDBToken } from 'common';
 import { logger } from '$lib/logger';
 import { isSurrealConnectionError } from 'common/surreal';
 
@@ -83,11 +83,14 @@ export class CentralAuthController {
 		this._userId = new StringRecordId(decoded.ID);
 	}
 
-	async sendSigninCode(phoneNumber: string): Promise<SendSigninCodeResponse> {
+	async sendSigninCode(
+		phoneNumber: string,
+		channel: MessagingChannel
+	): Promise<SendSigninCodeResponse> {
 		logger.info(LOG_TARGET, `Requesting signin code for ${phoneNumber}`);
 		const response = await fetch(`${this.client.apiBaseUrl}/auth/send_signin_code`, {
 			method: 'POST',
-			body: Body.json({ phone_number: phoneNumber })
+			body: Body.json({ phone_number: phoneNumber, channel })
 		});
 
 		logger.debug(LOG_TARGET, `Received response: ${response.status}`);

--- a/apps/desktop/src/common/index.ts
+++ b/apps/desktop/src/common/index.ts
@@ -453,3 +453,8 @@ export interface SurrealDBToken {
 	SC: string;
 	ID: string;
 }
+
+export enum MessagingChannel {
+	WhatsApp = 'whatsapp',
+	Telegram = 'telegram'
+}

--- a/apps/desktop/src/components/Login.svelte
+++ b/apps/desktop/src/components/Login.svelte
@@ -2,6 +2,7 @@
 	import { Label, Input, Button } from 'flowbite-svelte';
 	import { MobilePhoneSolid } from 'flowbite-svelte-icons';
 	import { CentralClient } from '../central';
+	import { MessagingChannel } from 'common';
 	const client = new CentralClient();
 
 	let phoneNumber = '+201069392983';
@@ -10,7 +11,7 @@
 	let isSignedIn = false;
 
 	async function sendCode() {
-		client.auth.sendSigninCode(phoneNumber).then(() => {
+		client.auth.sendSigninCode(phoneNumber, MessagingChannel.WhatsApp).then(() => {
 			isCodeSent = true;
 		});
 	}

--- a/apps/desktop/src/sdk/academic-year-course.ts
+++ b/apps/desktop/src/sdk/academic-year-course.ts
@@ -54,7 +54,7 @@ export enum Subject {
 	Geography = 'geography',
 	Geology = 'geology',
 	Dynamics = 'dynamics',
-	Philisophy = 'philisophy',
+	Philosophy = 'philosophy',
 	Physics = 'physics',
 	Chemistry = 'chemistry',
 	Mechanics = 'mechanics',

--- a/apps/desktop/src/sdk/common.ts
+++ b/apps/desktop/src/sdk/common.ts
@@ -71,7 +71,7 @@ export function nameFilter(name: string, autocomplete = false): string {
 		}
 	}
 
-	// Do two passes to avoid unnormalized characters
+	// Do two passes to avoid un-normalized characters
 	for (const i of dalIndexes) {
 		if (!(output[i - 2] === 'ع' && output[i - 1] === 'ب')) {
 			continue;

--- a/apps/telegram-bot/src/classes/chat.rs
+++ b/apps/telegram-bot/src/classes/chat.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TelegramChat {
+    pub id: i64,
+}

--- a/apps/telegram-bot/src/classes/mod.rs
+++ b/apps/telegram-bot/src/classes/mod.rs
@@ -1,0 +1,5 @@
+mod user;
+mod chat;
+
+pub use user::*;
+pub use chat::*;

--- a/apps/telegram-bot/src/classes/user.rs
+++ b/apps/telegram-bot/src/classes/user.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TelegramUser {
+    pub id: i64,
+    pub first_name: String,
+    pub last_name: String,
+}

--- a/apps/telegram-bot/src/functions/create_private_chat.rs
+++ b/apps/telegram-bot/src/functions/create_private_chat.rs
@@ -1,0 +1,31 @@
+use crate::tdlib::ClientId;
+use crate::{requests::TdLibType, TelegramClient, TelegramRequest};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, TelegramRequest)]
+pub struct CreatePrivateChat {
+    #[serde(rename = "@type")]
+    td_type: TdLibType,
+
+    #[serde(rename = "@client_id")]
+    client_id: ClientId,
+
+    #[serde(rename = "@extra")]
+    extra: String,
+
+    user_id: i64,
+
+    force: bool,
+}
+
+impl CreatePrivateChat {
+    pub fn new(client: &TelegramClient, user_id: i64) -> Self {
+        Self {
+            td_type: TdLibType::CreatePrivateChat,
+            client_id: client.client_id,
+            extra: client.generate_extra_handle(),
+            user_id,
+            force: false,
+        }
+    }
+}

--- a/apps/telegram-bot/src/functions/mod.rs
+++ b/apps/telegram-bot/src/functions/mod.rs
@@ -3,9 +3,17 @@ mod set_tdlib_parameters;
 mod set_verbosity_level;
 mod request_qrcode_authentication;
 mod check_authentication_password;
+mod search_user_by_phone_number;
+mod search_contacts;
+mod create_private_chat;
+mod send_message;
 
 pub use get_authorization_state::*;
 pub use set_tdlib_parameters::*;
 pub use set_verbosity_level::*;
 pub use request_qrcode_authentication::*;
 pub use check_authentication_password::*;
+pub use search_user_by_phone_number::*;
+pub use search_contacts::*;
+pub use create_private_chat::*;
+pub use send_message::*;

--- a/apps/telegram-bot/src/functions/search_contacts.rs
+++ b/apps/telegram-bot/src/functions/search_contacts.rs
@@ -1,0 +1,31 @@
+use crate::tdlib::ClientId;
+use crate::{requests::TdLibType, TelegramClient, TelegramRequest};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, TelegramRequest)]
+pub struct SearchContacts {
+    #[serde(rename = "@type")]
+    td_type: TdLibType,
+
+    #[serde(rename = "@client_id")]
+    client_id: ClientId,
+
+    #[serde(rename = "@extra")]
+    extra: String,
+
+    query: String,
+
+    limit: i32,
+}
+
+impl SearchContacts {
+    pub fn new(client: &TelegramClient, query: String) -> Self {
+        Self {
+            td_type: TdLibType::SearchContacts,
+            client_id: client.client_id,
+            extra: client.generate_extra_handle(),
+            query,
+            limit: 10
+        }
+    }
+}

--- a/apps/telegram-bot/src/functions/search_user_by_phone_number.rs
+++ b/apps/telegram-bot/src/functions/search_user_by_phone_number.rs
@@ -1,0 +1,31 @@
+use crate::tdlib::ClientId;
+use crate::{requests::TdLibType, TelegramClient, TelegramRequest};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, TelegramRequest)]
+pub struct SearchUserByPhoneNumber {
+    #[serde(rename = "@type")]
+    td_type: TdLibType,
+
+    #[serde(rename = "@client_id")]
+    client_id: ClientId,
+
+    #[serde(rename = "@extra")]
+    extra: String,
+
+    phone_number: String,
+
+    only_local: bool,
+}
+
+impl SearchUserByPhoneNumber {
+    pub fn new(client: &TelegramClient, phone_number: String) -> Self {
+        Self {
+            td_type: TdLibType::SearchUserByPhoneNumber,
+            client_id: client.client_id,
+            extra: client.generate_extra_handle(),
+            phone_number,
+            only_local: false
+        }
+    }
+}

--- a/apps/telegram-bot/src/functions/send_message.rs
+++ b/apps/telegram-bot/src/functions/send_message.rs
@@ -1,0 +1,73 @@
+use crate::tdlib::ClientId;
+use crate::{requests::TdLibType, TelegramClient, TelegramRequest};
+use serde::Serialize;
+
+#[derive(Serialize, Debug, Clone)]
+pub struct FormattedText {
+    #[serde(rename = "@type")]
+    td_type: TdLibType,
+
+    text: String,
+}
+
+impl FormattedText {
+    pub fn new(text: String) -> Self {
+        Self {
+            td_type: TdLibType::FormattedText,
+            text,
+        }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct InputMessageText {
+    #[serde(rename = "@type")]
+    td_type: TdLibType,
+
+    text: FormattedText,
+}
+
+impl InputMessageText {
+    pub fn new(text: FormattedText) -> Self {
+        Self {
+            td_type: TdLibType::InputMessageText,
+            text,
+        }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum InputMessageContent {
+    Text(InputMessageText),
+}
+
+#[derive(Serialize, Debug, Clone, TelegramRequest)]
+pub struct SendMessage {
+    #[serde(rename = "@type")]
+    td_type: TdLibType,
+
+    #[serde(rename = "@client_id")]
+    client_id: ClientId,
+
+    #[serde(rename = "@extra")]
+    extra: String,
+
+    chat_id: i64,
+
+    input_message_content: InputMessageContent,
+}
+
+impl SendMessage {
+    pub fn new(client: &TelegramClient, chat_id: i64, message: String) -> Self {
+        Self {
+            td_type: TdLibType::SendMessage,
+            client_id: client.client_id,
+            extra: client.generate_extra_handle(),
+            chat_id,
+            input_message_content: InputMessageContent::Text(InputMessageText::new(
+                FormattedText::new(message),
+            )),
+        }
+    }
+}

--- a/apps/telegram-bot/src/functions/set_tdlib_parameters.rs
+++ b/apps/telegram-bot/src/functions/set_tdlib_parameters.rs
@@ -47,7 +47,7 @@ pub struct SetTdLibParameters {
 impl SetTdLibParameters {
     pub fn new(client: &TelegramClient, api_id: i32, api_hash: String) -> Self {
         Self {
-            td_type: TdLibType::SetTdLibParameters,
+            td_type: TdLibType::SetTdlibParameters,
             client_id: client.client_id,
             extra: client.generate_extra_handle(),
             use_test_dc: false,

--- a/apps/telegram-bot/src/requests.rs
+++ b/apps/telegram-bot/src/requests.rs
@@ -2,197 +2,91 @@ use super::tdlib::ClientId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub enum TdLibType {
-    #[serde(rename = "updateOption")]
+    SendMessage,
     UpdateOption,
-
-    #[serde(rename = "updateAuthorizationState")]
+    Message,
+    UpdateMessageSendSucceeded,
+    UpdateMessageSendFailed,
+    UpdateMessageSendAcknowledged,
+    UpdateSavedMessagesTopic,
+    InputMessageText,
+    FormattedText,
     UpdateAuthorizationState,
-
-    #[serde(rename = "getAuthorizationState")]
     GetAuthorizationState,
-
-    #[serde(rename = "setLogVerbosityLevel")]
     SetLogVerbosityLevel,
-
-    #[serde(rename = "authorizationStateWaitTdlibParameters")]
     AuthorizationStateWaitTdlibParameters,
-
-    #[serde(rename = "updateDefaultBackground")]
     UpdateDefaultBackground,
-
-    #[serde(rename = "updateFileDownloads")]
     UpdateFileDownloads,
-
-    #[serde(rename = "updateConnectionState")]
     UpdateConnectionState,
-
-    #[serde(rename = "setTdlibParameters")]
-    SetTdLibParameters,
-
-    #[serde(rename = "updateAnimationSearchParameters")]
+    SetTdlibParameters,
     UpdateAnimationSearchParameters,
-
-    #[serde(rename = "sendPhoneNumberCode")]
     SendPhoneNumberCode,
-
-    #[serde(rename = "setAuthenticationPhoneNumber")]
     SetAuthenticationPhoneNumber,
-
-    #[serde(rename = "requestQrCodeAuthentication")]
     RequestQrCodeAuthentication,
-
-    #[serde(rename = "checkAuthenticationCode")]
     CheckAuthenticationCode,
-
-    #[serde(rename = "checkAuthenticationPassword")]
     CheckAuthenticationPassword,
-
-    #[serde(rename = "updateAccentColors")]
     UpdateAccentColors,
-
-    #[serde(rename = "updateProfileAccentColors")]
     UpdateProfileAccentColors,
-
-    #[serde(rename = "updateSpeechRecognitionTrial")]
     UpdateSpeechRecognitionTrial,
-
-    #[serde(rename = "updateAttachmentMenuBots")]
     UpdateAttachmentMenuBots,
-
-    #[serde(rename = "updateDiceEmojis")]
     UpdateDiceEmojis,
-
-    #[serde(rename = "updateActiveEmojiReactions")]
     UpdateActiveEmojiReactions,
-
-    #[serde(rename = "updateAvailableMessageEffects")]
     UpdateAvailableMessageEffects,
-
-    #[serde(rename = "updateChatThemes")]
     UpdateChatThemes,
-
-    #[serde(rename = "updateReactionNotificationSettings")]
     UpdateReactionNotificationSettings,
-
-    #[serde(rename = "updateChatFolders")]
     UpdateChatFolders,
-
-    #[serde(rename = "updateStoryStealthMode")]
     UpdateStoryStealthMode,
-
-    #[serde(rename = "updateHavePendingNotifications")]
     UpdateHavePendingNotifications,
-
-    #[serde(rename = "updateUser")]
     UpdateUser,
-
-    #[serde(rename = "updateScopeNotificationSettings")]
+    UpdateChatRemovedFromList,
     UpdateScopeNotificationSettings,
-
-    #[serde(rename = "updateUserStatus")]
     UpdateUserStatus,
-
-    #[serde(rename = "updateSupergroup")]
     UpdateSupergroup,
-
-    #[serde(rename = "updateBasicGroup")]
     UpdateBasicGroup,
-
-    #[serde(rename = "updateNewChat")]
     UpdateNewChat,
-
-    #[serde(rename = "updateChatNotificationSettings")]
     UpdateChatNotificationSettings,
-
-    #[serde(rename = "updateChatLastMessage")]
     UpdateChatLastMessage,
-
-    #[serde(rename = "updateChatReadInbox")]
     UpdateChatReadInbox,
-
-    #[serde(rename = "updateChatReadOutbox")]
     UpdateChatReadOutbox,
-
-    #[serde(rename = "updateChatAddedToList")]
     UpdateChatAddedToList,
-
-    #[serde(rename = "updateChatMessageAutoDeleteTime")]
     UpdateChatMessageAutoDeleteTime,
-
-    #[serde(rename = "updateChatPosition")]
     UpdateChatPosition,
-
-    #[serde(rename = "updateUserFullInfo")]
     UpdateUserFullInfo,
-
-    #[serde(rename = "updateChatIsTranslatable")]
     UpdateChatIsTranslatable,
-
-    #[serde(rename = "updateChatAvailableReactions")]
     UpdateChatAvailableReactions,
-
-    #[serde(rename = "updateChatVideoChat")]
     UpdateChatVideoChat,
-
-    #[serde(rename = "updateMessageInteractionInfo")]
     UpdateMessageInteractionInfo,
-
-    #[serde(rename = "updateSupergroupFullInfo")]
     UpdateSupergroupFullInfo,
-
-    #[serde(rename = "updateDefaultReactionType")]
     UpdateDefaultReactionType,
-
-    #[serde(rename = "internalLinkTypeQrCodeAuthentication")]
     InternalLinkTypeQrCodeAuthentication,
-
-    #[serde(rename = "updateNewMessage")]
     UpdateNewMessage,
-
-    #[serde(rename = "error")]
+    SearchUserByPhoneNumber,
+    SearchContacts,
+    CreatePrivateChat,
+    Users,
+    User,
+    Chats,
+    Chat,
     Error,
-
-    #[serde(rename = "ok")]
     Ok,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub enum AuthorizationState {
-    #[serde(rename = "authorizationStateWaitTdlibParameters")]
     AuthorizationStateWaitTdlibParameters,
-
-    #[serde(rename = "authorizationStateWaitPhoneNumber")]
     AuthorizationStateWaitPhoneNumber,
-
-    #[serde(rename = "authorizationStateWaitEmailAddress")]
     AuthorizationStateWaitEmailAddress,
-
-    #[serde(rename = "authorizationStateWaitEmailCode")]
     AuthorizationStateWaitEmailCode,
-
-    #[serde(rename = "authorizationStateWaitCode")]
     AuthorizationStateWaitCode,
-
-    #[serde(rename = "authorizationStateWaitOtherDeviceConfirmation")]
     AuthorizationStateWaitOtherDeviceConfirmation,
-
-    #[serde(rename = "authorizationStateWaitRegistration")]
     AuthorizationStateWaitRegistration,
-
-    #[serde(rename = "authorizationStateWaitPassword")]
     AuthorizationStateWaitPassword,
-
-    #[serde(rename = "authorizationStateReady")]
     AuthorizationStateReady,
-
-    #[serde(rename = "authorizationStateLoggingOut")]
     AuthorizationStateLoggingOut,
-
-    #[serde(rename = "authorizationStateClosing")]
     AuthorizationStateClosing,
-
-    #[serde(rename = "authorizationStateClosed")]
     AuthorizationStateClosed,
 }
 
@@ -244,6 +138,9 @@ pub struct TDLibResponse {
     pub authorization_state: Option<AuthorizationStateObject>,
 
     pub state: Option<ConnectionStateObject>,
+
+    #[serde(flatten)]
+    pub data: serde_json::Value,
 }
 
 pub trait TelegramRequest: Serialize {

--- a/apps/telegram-bot/src/tdlib.rs
+++ b/apps/telegram-bot/src/tdlib.rs
@@ -10,7 +10,6 @@ extern "C" {
     fn td_create_client_id() -> c_int;
     fn td_send(client_id: c_int, request: *const c_char);
     fn td_receive(timeout: c_double) -> *const c_char;
-    // fn td_execute(request: *const c_char) -> *const c_char;
 }
 
 pub fn new_client() -> ClientId {
@@ -21,16 +20,6 @@ pub fn send(client_id: ClientId, request: &str) {
     let cstring = CString::new(request).unwrap();
     unsafe { td_send(client_id, cstring.as_ptr()) }
 }
-
-// pub fn execute(request: &str) -> Option<String> {
-//     let cstring = CString::new(request).unwrap();
-//     let result = unsafe {
-//         td_execute(cstring.as_ptr())
-//             .as_ref()
-//             .map(|response| CStr::from_ptr(response).to_string_lossy().into_owned())
-//     };
-//     result
-// }
 
 pub fn receive(timeout: f64) -> Option<String> {
     unsafe {


### PR DESCRIPTION
In `central` -> `auth`:

The function `sendSigninCode` was modified to be
```ts
sendSigninCode(phoneNumber: string, channel: MessagingChannel)
```

Where `MessagingChannel` is an enum:

```ts
export enum MessagingChannel {
  WhatsApp = 'whatsapp',
  Telegram = 'telegram'
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated support for sending sign-in codes via WhatsApp and Telegram.
	- Added functionality for searching contacts and users by phone number within the Telegram bot.
	- Introduced the ability to send messages through the Telegram bot.

- **Bug Fixes**
	- Corrected spelling of "Philosophy" in the Subject enum.

- **Documentation**
	- Enhanced testability of the Telegram client and improved error handling and logging practices.

- **Refactor**
	- Improved modularity and maintainability of messaging functionalities across the application. 

- **Chores**
	- Updated various components to accommodate new messaging channel features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->